### PR TITLE
Only call `before_action` when the method exists

### DIFF
--- a/lib/turbolinks/redirection.rb
+++ b/lib/turbolinks/redirection.rb
@@ -3,7 +3,7 @@ module Turbolinks
     extend ActiveSupport::Concern
 
     included do
-      before_action :set_turbolinks_location_header_from_session
+      before_action :set_turbolinks_location_header_from_session if respond_to?(:before_action)
     end
 
     def redirect_to(url = {}, options = {})


### PR DESCRIPTION
We should be able to call `ActiveSupport.run_load_hooks(:action_controller, self)` in a `ActionController::Metal` class. Since it doesn't have the `before_action` method the turbolinks hook will fail. To fix it I'm checking if the method exists.

[We have a test in Rails to make sure that works](https://github.com/rails/rails/blob/3be9a34e78835a8dafc3438f60afb412613773b9/railties/test/application/loading_test.rb#L322-L350)

Closes #2.
