### PR TITLE
Add support for notice option in redirect_to

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+## Support for notice option in redirect_to
+
+To handle and display notice message from redirect you have to implement
+your own JS method `turbolinksNotice(message)`. This method will
+be called just before `Turbolinks.visit`.
+
+The simplest example of that method looks like this:
+```
+this.turbolinksNotice = (message) ->
+  alert(message)
+```
+
+IMPORTANT: The body content will be replaced by turbolinks as a result of
+`Turbolinks.visit` call so you should store the message in JS variable
+and display it in `turbolinks:load` event handler

--- a/lib/turbolinks/redirection.rb
+++ b/lib/turbolinks/redirection.rb
@@ -8,10 +8,11 @@ module Turbolinks
 
     def redirect_to(url = {}, options = {})
       turbolinks = options.delete(:turbolinks)
+      notice = options.delete(:notice)
 
       super.tap do
         if turbolinks != false && request.xhr? && !request.get?
-          visit_location_with_turbolinks(location, turbolinks)
+          visit_location_with_turbolinks(location, turbolinks, notice)
         else
           if request.headers["Turbolinks-Referrer"]
             store_turbolinks_location_in_session(location)
@@ -21,13 +22,14 @@ module Turbolinks
     end
 
     private
-      def visit_location_with_turbolinks(location, action)
+      def visit_location_with_turbolinks(location, action, notice)
         visit_options = {
           action: action.to_s == "advance" ? action : "replace"
         }
 
         script = []
         script << "Turbolinks.clearCache()"
+        script << "turbolinksNotice(#{notice.to_json})" if notice.present?
         script << "Turbolinks.visit(#{location.to_json}, #{visit_options.to_json})"
 
         self.status = 200


### PR DESCRIPTION
If notice option is specified then we call turbolinksNotice method
in response. This method should be implemented
by developer to handle notice display in the app.
