### PR TITLE
Allow using of turbolinks gem without Sprockets

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -14,7 +14,7 @@ module Turbolinks
   class Engine < ::Rails::Engine
     config.turbolinks = ActiveSupport::OrderedOptions.new
     config.turbolinks.auto_include = true
-    config.assets.paths += [Turbolinks::Source.asset_path]
+    config.assets.paths += [Turbolinks::Source.asset_path] if config.respond_to?(:assets)
 
     initializer :turbolinks do |app|
       ActiveSupport.on_load(:action_controller) do


### PR DESCRIPTION
I'm trying to use Turbolinks with Webpack instead of Sprockets, to do this I'm getting `turbolinks` js from npm package using Yarn but I still want to use this gem to get `Turbolinks::Redirection` in my controller automatically. This allow to use this gem when Sprockets is not enabled.

Closes #16