### PR TITLE
Allow option turbolinks: true with redirect_to

### DIFF
--- a/lib/turbolinks/redirection.rb
+++ b/lib/turbolinks/redirection.rb
@@ -10,7 +10,7 @@ module Turbolinks
       turbolinks = options.delete(:turbolinks)
 
       super.tap do
-        if turbolinks != false && request.xhr? && !request.get?
+        if turbolinks || (turbolinks.nil? && request.xhr? && !request.get?)
           visit_location_with_turbolinks(location, turbolinks)
         else
           if request.headers["Turbolinks-Referrer"]


### PR DESCRIPTION
When we need to use tubolinks with redirect_to even if not get or xhr request.
Simulates classic functionality.