### PR TITLE
assert_redirected_to

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -1,5 +1,6 @@
 require 'turbolinks/version'
 require 'turbolinks/redirection'
+require 'turbolinks/assertions'
 require 'turbolinks/source'
 
 module Turbolinks
@@ -20,6 +21,8 @@ module Turbolinks
       ActiveSupport.on_load(:action_controller) do
         if app.config.turbolinks.auto_include
           include Controller
+
+          ::ActionDispatch::Assertions.include ::Turbolinks::Assertions
         end
       end
     end

--- a/lib/turbolinks/assertions.rb
+++ b/lib/turbolinks/assertions.rb
@@ -1,0 +1,46 @@
+module Turbolinks
+  module Assertions
+    TURBOLINKS_VISIT = /Turbolinks\.visit\("([^"]+)", {"action":"([^"]+)"}\)/
+
+    def assert_redirected_to(options = {}, message = nil)
+      if turbolinks_request?
+        assert_turbolinks_visited(options, message)
+      else
+        super
+      end
+    end
+
+    def assert_turbolinks_visited(options = {}, message = nil)
+      assert_response(:ok, message)
+      assert_equal("text/javascript", response.content_type)
+
+      visit_location, visit_action = turbolinks_visit_location_and_action
+
+      redirect_is       = normalize_argument_to_redirection(visit_location)
+      redirect_expected = normalize_argument_to_redirection(options)
+
+      message ||= "Expected response to be a Turbolinks visit to <#{redirect_expected}> but was a visit to <#{redirect_is}>"
+      assert_operator redirect_expected, :===, redirect_is, message
+    end
+
+    # Rough heuristic to detect whether this was a Turbolinks request:
+    # non-GET request with a text/javascript response.
+    #
+    # Technically we'd check that Turbolinks-Referrer request header is
+    # also set, but that'd require us to pass the header from post/patch/etc
+    # test methods by overriding them to provide a `turbolinks:` option.
+    #
+    # We can't check `request.xhr?` here, either, since the X-Requested-With
+    # header is cleared after controller action processing to prevent it
+    # from leaking into subsequent requests.
+    def turbolinks_request?
+      !request.get? && response.content_type == "text/javascript"
+    end
+
+    def turbolinks_visit_location_and_action
+      if response.body =~ TURBOLINKS_VISIT
+        [ $1, $2 ]
+      end
+    end
+  end
+end


### PR DESCRIPTION
`assert_redirected_to` checks for a `Turbolinks.visit` response to Turbolinks requests.

Before
```ruby
test "creating a new HQ project" do
  post :create, xhr: true, params: { project_kind: "new_project" }

  assert_response :ok
  assert_match 'Turbolinks.visit', response.body
  assert_match projects_url, response.body
end
```
After
```ruby
test "creating a new HQ project" do
  post :create, xhr: true, params: { project_kind: "new_project" }
  assert_redirected_to projects_url
end
```