### PR TITLE
added missing require statement for rendering

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -1,5 +1,6 @@
 require 'turbolinks/version'
 require 'turbolinks/redirection'
+require 'turbolinks/rendering'
 require 'turbolinks/assertions'
 require 'turbolinks/source'
 


### PR DESCRIPTION
PR #25 added a new file `turbolinks/rendering.rb` and `lib/turbolinks`
did not have a require statement for this file.