### PR TITLE
Fix "warning: assigned but unused variable - visit_action"

### DIFF
--- a/lib/turbolinks/assertions.rb
+++ b/lib/turbolinks/assertions.rb
@@ -14,7 +14,7 @@ module Turbolinks
       assert_response(:ok, message)
       assert_equal("text/javascript", response.content_type)
 
-      visit_location, visit_action = turbolinks_visit_location_and_action
+      visit_location, _ = turbolinks_visit_location_and_action
 
       redirect_is       = normalize_argument_to_redirection(visit_location)
       redirect_expected = normalize_argument_to_redirection(options)


### PR DESCRIPTION
This fixes following warnings: 

```
/home/travis/build/rails/rails/vendor/bundle/ruby/2.5.0/gems/turbolinks-5.1.0/lib/turbolinks/assertions.rb:17: warning: assigned but unused variable - visit_action
```