### PR TITLE
Return Turbolinks-Status header from render method

### DIFF
--- a/lib/turbolinks.rb
+++ b/lib/turbolinks.rb
@@ -9,6 +9,7 @@ module Turbolinks
 
     included do
       include Redirection
+      include Rendering
     end
   end
 

--- a/lib/turbolinks/rendering.rb
+++ b/lib/turbolinks/rendering.rb
@@ -1,0 +1,11 @@
+module Turbolinks
+  module Rendering
+    extend ActiveSupport::Concern
+
+    def render(*)
+      super.tap do
+        response.headers["Turbolinks-Status"] = "OK"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Revised version of #25.
See https://github.com/turbolinks/turbolinks/pull/334