### PR TITLE
Bump 5.1.1

### DIFF
--- a/lib/turbolinks/version.rb
+++ b/lib/turbolinks/version.rb
@@ -1,3 +1,3 @@
 module Turbolinks
-  VERSION = '5.1.0'
+  VERSION = '5.1.1'
 end


### PR DESCRIPTION
## Summary

* The latest version of https://github.com/turbolinks/turbolinks is v5.1.1. So please bump up v5.1.1
* I want to fix warning in rails test.

https://github.com/rails/rails/pull/32496#issuecomment-379712870