### PR TITLE
Add source_code_uri metadata

### DIFF
--- a/turbolinks.gemspec
+++ b/turbolinks.gemspec
@@ -10,6 +10,9 @@ Gem::Specification.new do |s|
   s.summary     = 'Turbolinks makes navigating your web application faster'
   s.description = 'Rails engine for Turbolinks 5 support'
   s.files       = Dir["lib/turbolinks.rb", "lib/turbolinks/*.rb", "README.md", "LICENSE"]
+  s.metadata = {
+    "source_code_uri" => "https://github.com/turbolinks/turbolinks-rails",
+  }
 
   s.add_dependency 'turbolinks-source', '~> 5.1'
 end


### PR DESCRIPTION
I searched turbolinks/turbolinks for this gem's source since there is a link to that repo from https://rubygems.org/gems/turbolinks.
According to https://guides.rubygems.org/specification-reference/#metadata, 
this change should add an link to rubygems.org

closes #19