### PR TITLE
Redirection : advance by default

### DIFF
--- a/lib/turbolinks/redirection.rb
+++ b/lib/turbolinks/redirection.rb
@@ -23,7 +23,7 @@ module Turbolinks
     private
       def visit_location_with_turbolinks(location, action)
         visit_options = {
-          action: action.to_s == "advance" ? action : "replace"
+          action: action.to_s == "replace" ? action : "advance"
         }
 
         script = []


### PR DESCRIPTION
According to the docs, https://github.com/turbolinks/turbolinks#application-visits, the default behaviour is "advance" : 

> The default visit action is advance.

Thus this should be reflected in the "redirection" scenario.

